### PR TITLE
Current catkin branch doesn't work on Fedora

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -3,6 +3,7 @@ require 'mkmf'
 CONFIG['CC'] = "g++"
 if RUBY_VERSION >= "1.9"
     $CFLAGS += " -DRUBY_IS_19"
+    $CPPFLAGS += " -DRUBY_IS_19"
 end
 
 if ENV['RUBY_SOURCE_DIR']


### PR DESCRIPTION
The latest version of utilrb in the catkin branch doesn't compile due to invalid detection for Ruby > 1.9. The latest master branch works great, minus https://github.com/orocos-toolchain/utilrb/pull/2.

I'm really confused on the branching here. Which one is newer?
