### PR TITLE
Updated manifest.xml and package.xml for autoproj/rosdep compatibility

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -11,6 +11,7 @@
   <license>CeCILL-B (BSD-like)</license>
   
   <rosdep name="ruby"/>
+  <rosdep name="facets" />
   <rosdep name="hoe" />
   <depend_optional package="hoe-yard" />
   <rosdep name="rake-compiler" />

--- a/package.xml
+++ b/package.xml
@@ -12,11 +12,14 @@
   <run_depend>catkin</run_depend>
 
   <build_depend>ruby</build_depend>
+  <build_depend>facets</build_depend>
   <build_depend>hoe</build_depend>
   <build_depend>rake-compiler</build_depend>
   <build_depend>libreadline-dev</build_depend>
 
   <run_depend>ruby</run_depend>
+  <run_depend>facets</run_depend>
+  <run_depend>hoe</run_depend>
   <run_depend>libreadline</run_depend>
 
   <export>


### PR DESCRIPTION
This pull request tracks manifest changes in utilrb for autoproj/rosdep compatibility and for consistency between `manifest.xml` and `package.xml`. See discussion started in https://github.com/orocos-toolchain/utilrb/issues/5.
See also @doudou's comments on the outdated commit https://github.com/meyerj/utilrb/commit/6a156fd71244452de539fb514a8ae213e5464ad5.
