### PR TITLE
allow */lib64/* as pkg config directory

### DIFF
--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -451,8 +451,8 @@ module Utilrb
         end
 
 
-        FOUND_PATH_RX = /Scanning directory '(.*\/)((?:lib|share)\/.*)'$/
-        NONEXISTENT_PATH_RX = /Cannot open directory '.*\/((?:lib|share)\/.*)' in package search path:.*/
+        FOUND_PATH_RX = /Scanning directory '(.*\/)((?:lib|lib64|share)\/.*)'$/
+        NONEXISTENT_PATH_RX = /Cannot open directory '.*\/((?:lib|lib64|share)\/.*)' in package search path:.*/
 
         # Returns the system-wide search path that is embedded in pkg-config
         def self.default_search_path


### PR DESCRIPTION
This allows pkg-config paths like /usr/lib64/pkgconfig/.

To be discussed:
Actually we should not parse/find the *.pc files ourselves at all, but instead use pkg-config as far as possible, IMHO (e.g. use the --exists switch instead of looking for a <name>.pc file). At least we should not force the paths to contain specific strings.