### PR TITLE
pkgconfig: fix parsing default search path

### DIFF
--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -461,7 +461,7 @@ module Utilrb
         end
 
 
-        FOUND_PATH_RX = /Scanning directory '(.*\/)((?:lib|lib64|share)\/.*)'$/
+        FOUND_PATH_RX = /Scanning directory #?\d* ?'(.*\/)((?:lib|lib64|share)\/.*)'$/
         NONEXISTENT_PATH_RX = /Cannot open directory '.*\/((?:lib|lib64|share)\/.*)' in package search path:.*/
 
         # Returns the system-wide search path that is embedded in pkg-config


### PR DESCRIPTION
pkg-config 0.29 reports the scanning directory differently than for example 
pkg-config 0.26 (Ubuntu 14.04)

pkg-config 0.29:
      
    Scanning directory #3 '/usr/local/lib/pkgconfig'

pkg-config 0.26:

    Scanning directory '/usr/local/lib/pkgconfig'