### PR TITLE
Refactor PkgConfig

### DIFF
--- a/lib/utilrb/marshal.rb
+++ b/lib/utilrb/marshal.rb
@@ -1,0 +1,3 @@
+require 'utilrb/kernel/require'
+require_dir(__FILE__)
+

--- a/lib/utilrb/marshal/load_with_missing_constants.rb
+++ b/lib/utilrb/marshal/load_with_missing_constants.rb
@@ -1,26 +1,32 @@
 module Marshal
-    if defined? BasicObject
-        class BlackHole < BasicObject
-        end
-    end
-
     class BlackHole
         class << self
-            :name
+            attr_reader :name
         end
 
         def initialize(*args)
         end
 
+        def hash
+            __id__
+        end
+
+        def eql?(obj)
+            equal?(obj)
+        end
+
         attr_reader :__content__
         def method_missing(*args)
+            ::Kernel.puts args.inspect
+            ::Kernel.puts ::Kernel.caller
         end
         def self._load(*args)
             hole = BlackHole.new
             hole.instance_variable_set(:@__content__, args)
         end
 
-        def self.method_missing(*args)
+        def self.method_missing(*args, **options)
+            BlackHole.new
         end
     end
 
@@ -32,20 +38,11 @@ module Marshal
         self.load(str_or_io)
     rescue Exception => e
         case e.message
-        when /undefined class\/module ((?:\w+::)+)$/
-            names = $1.split('::')
-            missing = names.pop
-            base = names.inject(Object) { |m, n| m.const_get(n) }
-            base.const_set(missing, Module.new)
-
-            if original_pos
-                str_or_io.seek(original_pos)
-            end
-            retry
-        when /undefined class\/module ((?:\w+::)+)(\w+)$/
-            mod, klass   = $1, $2
-            full_name = "#{mod}#{klass}"
-            mod = mod.split('::').inject(Object) { |m, n| m.const_get(n) }
+        when /undefined class\/module ((?:\w+)(?:::\w+)*)(?:::)?$/
+            full_name = $1
+            path = $1.split('::')
+            *path, klass = *path
+            mod = path.inject(Object) { |m, n| m.const_get(n) }
 
             blackhole = Class.new(BlackHole) do
                 @name = full_name

--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -41,15 +41,6 @@ module Utilrb
         VAR_NAME_RX     = /\w+/
         FIELD_NAME_RX   = /[\w\.\-]+/
 
-        class << self
-            attr_reader :loaded_packages
-
-            def clear_cache
-                loaded_packages.clear
-            end
-        end
-        @loaded_packages = Hash.new
-
         def self.load(path, preset_variables)
             pkg_name = File.basename(path, ".pc")
             pkg = Class.instance_method(:new).bind(PkgConfig).call(pkg_name)
@@ -60,17 +51,13 @@ module Utilrb
         # Returns the pkg-config object that matches the given name, and
         # optionally a version string
         def self.get(name, version_spec = nil, preset_variables = Hash.new)
-            if !(candidates = loaded_packages[name])
-                paths = find_all_package_files(name)
-                if paths.empty?
-                    raise NotFound.new(name), "cannot find the pkg-config specification for #{name}"
-                end
+            paths = find_all_package_files(name)
+            if paths.empty?
+                raise NotFound.new(name), "cannot find the pkg-config specification for #{name}"
+            end
 
-                candidates = Array.new
-                paths.each do |p|
-                    candidates << PkgConfig.load(p, preset_variables)
-                end
-                loaded_packages[name] = candidates
+            candidates = paths.map do |p|
+                PkgConfig.load(p, preset_variables)
             end
 
             # Now try to find a matching spec

--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -452,6 +452,8 @@ module Utilrb
         # Yields the package names of available packages. If +regex+ is given,
         # lists only the names that match the regular expression.
         def self.each_package(regex = nil)
+            return enum_for(__method__) if !block_given?
+
             seen = Set.new
             each_pkgconfig_directory do |dir|
                 Dir.glob(File.join(dir, '*.pc')) do |file|

--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -55,6 +55,11 @@ module Utilrb
             pkg
         end
 
+        # @deprecated {PkgConfig} does not cache the packages anymore, so no
+        #   need to call this method
+        def self.clear_cache
+        end
+
         # Returns the pkg-config object that matches the given name, and
         # optionally a version string
         def self.get(name, version_spec = nil, preset_variables = Hash.new, minimal: false)

--- a/lib/utilrb/test.rb
+++ b/lib/utilrb/test.rb
@@ -4,10 +4,10 @@ if ENV['TEST_ENABLE_COVERAGE'] != '0'
     begin
         require 'simplecov'
         require 'coveralls'
-        SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-            SimpleCov::Formatter::HTMLFormatter,
-            Coveralls::SimpleCov::Formatter
-        ]
+        SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+            [SimpleCov::Formatter::HTMLFormatter,
+             Coveralls::SimpleCov::Formatter]
+        )
         SimpleCov.start do
             add_filter "/test/"
         end

--- a/lib/utilrb/timepoints.rb
+++ b/lib/utilrb/timepoints.rb
@@ -15,8 +15,15 @@ module Utilrb
         end
 
         def format_timepoints
+            start_points = Hash.new
             result = []
             @timepoints.inject(@timepoints.first.first) do |last_t, (t, name)|
+                if name.last == 'start'
+                    start_points[name[0..-2]] = t
+                elsif name.last == 'done'
+                    total = t - start_points.delete(name[0..-2])
+                    name = name + ["total=%.3f" % total]
+                end
                 result << name + [t - last_t]
                 t
             end

--- a/test/test_marshal.rb
+++ b/test/test_marshal.rb
@@ -1,0 +1,47 @@
+require 'utilrb/test'
+require 'utilrb/marshal'
+
+module MarshalLoadWithMissingConstantsEnv
+end
+
+describe Marshal do
+    describe "#load_with_missing_constants" do
+        after do
+            Object.const_set :MarshalLoadWithMissingConstantsEnv, Module.new
+        end
+
+        it "resolves existing constants as expected" do
+            MarshalLoadWithMissingConstantsEnv.const_set 'Test', (klass = Class.new)
+            dumped = Marshal.dump(klass.new)
+            obj = Marshal.load_with_missing_constants(dumped)
+            assert_kind_of klass, obj
+        end
+
+        it "creates missing classes as needed" do
+            MarshalLoadWithMissingConstantsEnv.const_set 'Test', (klass = Class.new)
+            dumped = Marshal.dump(klass.new)
+            Object.const_set :MarshalLoadWithMissingConstantsEnv, Module.new
+            obj = Marshal.load_with_missing_constants(dumped)
+            assert_same obj.class, MarshalLoadWithMissingConstantsEnv::Test
+            assert_kind_of Marshal::BlackHole, obj
+            assert_equal "MarshalLoadWithMissingConstantsEnv::Test", obj.class.name
+        end
+
+        it "resolves missing namespaces recursively" do
+            MarshalLoadWithMissingConstantsEnv.const_set 'Test', (namespace = Module.new)
+            MarshalLoadWithMissingConstantsEnv::Test.const_set 'Test', (klass = Class.new)
+            dumped = Marshal.dump(klass.new)
+            Object.const_set :MarshalLoadWithMissingConstantsEnv, Module.new
+            obj = Marshal.load_with_missing_constants(dumped)
+
+            blackhole_namespace = MarshalLoadWithMissingConstantsEnv::Test
+            assert(blackhole_namespace < Marshal::BlackHole)
+            assert_equal "MarshalLoadWithMissingConstantsEnv::Test", blackhole_namespace.name
+            assert_same obj.class, blackhole_namespace::Test
+
+            assert_kind_of Marshal::BlackHole, obj
+            assert_equal "MarshalLoadWithMissingConstantsEnv::Test::Test", obj.class.name
+        end
+    end
+end
+

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -89,8 +89,6 @@ class TC_PkgConfig < Minitest::Test
                     puts "#{name} #{action_name}"
                     puts "  pure ruby:  #{pure_ruby.inspect}"
                     puts "  cpkgconfig: #{cpkgconfig.inspect}"
-                    puts "contents:"
-                    puts pkg.file.join("\n")
                 end
             end
         end

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -9,7 +9,6 @@ class TC_PkgConfig < Minitest::Test
     end
     def teardown
 	ENV['PKG_CONFIG_PATH'] = @old_pkg_config_path
-        PkgConfig.clear_cache
     end
 
     PkgConfig = Utilrb::PkgConfig


### PR DESCRIPTION
Apart from two minor changes, this suite of commits is mainly about removing the cache in Utilrb::PkgConfig, and giving more flexibility when loading the pkg-config information.

The goal is here is to give a choice. In e.g. orogen, one needs to resolve all the cflags and friends. In orocos.rb/Syskit, we're only interested in getting the variables, which is much MUCH simpler to load.

Also closes #29 