### PR TITLE
pkgconfig: adapt FOUND_PATH_RX to handle debug out of pkgconfig<=0.29.1

### DIFF
--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -461,7 +461,7 @@ module Utilrb
         end
 
 
-        FOUND_PATH_RX = /Scanning directory '(.*\/)((?:lib|lib64|share)\/.*)'$/
+        FOUND_PATH_RX = /Scanning directory (#[0-9]\+\s\+)?(.*\/)((?:lib|lib64|share)\/.*)'$/
         NONEXISTENT_PATH_RX = /Cannot open directory '.*\/((?:lib|lib64|share)\/.*)' in package search path:.*/
 
         # Returns the system-wide search path that is embedded in pkg-config


### PR DESCRIPTION
This fixes the broken Utilrb::PkgConfig.default_search_path on Ubuntu Xenial

pkgconfig version 0.26: Scanning directory '/usr/share/pkgconfig' 
pkgconfig version 0.29.1: Scanning directory #6 'usr/share/pkgconfig'