### PR TITLE
pkgconfig: minor fixes

### DIFF
--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -74,7 +74,11 @@ module Utilrb
             end
 
             # Now try to find a matching spec
-            find_matching_version(candidates, version_spec)
+            if version_match = find_matching_version(candidates, version_spec)
+                version_match
+            else
+                raise NotFound, "found #{candidates.size} packages for #{name}, but none match the version specification #{version_spec}"
+            end
         end
 
         # Finds the provided package and optional version and returns its

--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -66,10 +66,11 @@ module Utilrb
                     raise NotFound.new(name), "cannot find the pkg-config specification for #{name}"
                 end
 
-                candidates = loaded_packages[name] = Array.new
+                candidates = Array.new
                 paths.each do |p|
                     candidates << PkgConfig.load(p, preset_variables)
                 end
+                loaded_packages[name] = candidates
             end
 
             # Now try to find a matching spec

--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -466,8 +466,8 @@ module Utilrb
         end
 
 
-        FOUND_PATH_RX = /Scanning directory '(.*\/)((?:lib|lib64|share)\/.*)'$/
-        NONEXISTENT_PATH_RX = /Cannot open directory '.*\/((?:lib|lib64|share)\/.*)' in package search path:.*/
+        FOUND_PATH_RX = /Scanning directory (?:#\d+ )?'(.*\/)((?:lib|lib64|share)\/.*)'$/
+        NONEXISTENT_PATH_RX = /Cannot open directory (?:#\d+ )?'.*\/((?:lib|lib64|share)\/.*)' in package search path:.*/
 
         # Returns the system-wide search path that is embedded in pkg-config
         def self.default_search_path

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -19,6 +19,20 @@ class TC_PkgConfig < Minitest::Test
 	PkgConfig.new('test_pkgconfig')
     end
 
+    def test_path_autodetection_regexp
+        # PkgConfig 0.26
+        assert("Scanning directory '/usr/share/pkgconfig'" =~ Utilrb::PkgConfig::FOUND_PATH_RX)
+        assert_equal '/usr/share/pkgconfig', "#{$1}#{$2}"
+        assert("Cannot open directory '/usr/share/pkgconfig' in package search path:" =~ Utilrb::PkgConfig::NONEXISTENT_PATH_RX)
+        assert_equal 'share/pkgconfig', $1
+
+        # PkgConfig 0.29.1
+        assert("Scanning directory #10 '/usr/share/pkgconfig'" =~ Utilrb::PkgConfig::FOUND_PATH_RX)
+        assert_equal '/usr/share/pkgconfig', "#{$1}#{$2}"
+        assert("Cannot open directory #10 '/usr/share/pkgconfig' in package search path:" =~ Utilrb::PkgConfig::NONEXISTENT_PATH_RX)
+        assert_equal 'share/pkgconfig', $1
+    end
+
     def test_load
 	pkg = PkgConfig.new('test_pkgconfig')
 	assert_equal('test_pkgconfig', pkg.name)


### PR DESCRIPTION
There is now three versions of this fix

Alex: https://github.com/orocos-toolchain/utilrb/pull/29
Mine: https://github.com/orocos-toolchain/utilrb/pull/30/commits/28052ae316055fc34824abb431b7fcea5227db09
Thomas: https://github.com/orocos-toolchain/utilrb/pull/31

Alex is IMO too generic (not matching specifically the pattern)
Thomas' is broken (Ruby regexp are mostly perl-compatible, i.e. no need to quote +)

It's left with mine. I was stupid and did not extract it into a separate PR (I'm waiting for next week's demos at DFKI to pass before I merge https://github.com/orocos-toolchain/utilrb/pull/30 and related pull requests). This is what this PR is about, with some additional bugfixes to get the test suite to pass on my system.