### PR TITLE
logger: include the superclass when resolving the default logger

### DIFF
--- a/lib/utilrb/logger/hierarchy.rb
+++ b/lib/utilrb/logger/hierarchy.rb
@@ -130,8 +130,13 @@ class Logger
                                 break
                             end
                         end
+
                         if m.respond_to?(:superclass)
                             m = m.superclass
+                            if m.respond_to?(:logger)
+                                parent_module = m
+                                break
+                            end
                         else
                             m = nil; break
                         end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -178,6 +178,10 @@ class TC_Logger < Minitest::Test
     def test_hierarchy_can_resolve_parent_logger_in_subclasses_where_the_subclass_parent_module_is_not_providing_a_logger
         assert_equal "root_logger", NotALoggingModule::HierarchyTest.logger
     end
+    def test_hierarchy_resolution_starts_at_superclass_if_enclosing_module_does_not_provide_a_logger
+        flexmock(HierarchyTest::HierarchyTest).should_receive(logger: "specific_class_logger")
+        assert_equal "specific_class_logger", NotALoggingModule::HierarchyTest.logger
+    end
     def test_hierarchy_resolves_the_parent_module_first_even_in_subclasses
         assert_equal "other_logger", HierarchyTestForSubclass::HierarchyTest.logger
     end


### PR DESCRIPTION
The following setup

```
   module WithLogger
      extend Logger::Root(...)
      class Base
         extend Logger::Hierarchy
      end
   end

   module NoLogger
      class Derived < Base
          extend Logger::Hierarchy
      end
   end
```

was not considering Base's logger, which is really unexpected. It would
instead go directly to WithLogging's logger.

This commit adds Base in the search order.