### PR TITLE
Fix recursive package require

### DIFF
--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -74,7 +74,11 @@ module Utilrb
 
             # Now try to find a matching spec
             if match = find_matching_version(candidates, version_spec)
-                match
+                if version_spec.eql? match
+                    return
+                else
+                    match
+                end
             else
                 raise NotFound, "found #{candidates.size} packages for #{name}, but none match the version specification #{version_spec}"
             end
@@ -111,6 +115,10 @@ module Utilrb
                     elsif op == "<=" then [-1, 0]
                     elsif op == ">=" then [1, 0]
                     end
+
+                if requested_version.nil?
+                    return version_spec
+                end
 
                 requested_version = requested_version.split('.').map { |v| Integer(v) }
 

--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -62,7 +62,9 @@ module Utilrb
 
         # Returns the pkg-config object that matches the given name, and
         # optionally a version string
-        def self.get(name, version_spec = nil, preset_variables = Hash.new, minimal: false, pkg_config_path: self.pkg_config_path, memo: Hash.new )
+        def self.get(name, version_spec = nil, preset_variables = Hash.new,
+            minimal: false, pkg_config_path: self.pkg_config_path, memo: Hash.new)
+
             paths = find_all_package_files(name, pkg_config_path: pkg_config_path)
             if paths.empty?
                 raise NotFound.new(name), "cannot find the pkg-config specification for #{name}"
@@ -76,7 +78,8 @@ module Utilrb
             if match = find_matching_version(candidates, version_spec)
                 memo[[name, version_spec]] = [false, match]
             else
-                raise NotFound, "found #{candidates.size} packages for #{name}, but none match the version specification #{version_spec}"
+                raise NotFound, "found #{candidates.size} packages for #{name},"\
+                    " but none match the version specification #{version_spec}"
             end
 
             match.load_fields(memo: memo) unless minimal

--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -75,7 +75,7 @@ module Utilrb
             # Now try to find a matching spec
             if match = find_matching_version(candidates, version_spec)
                 if version_spec.eql? match
-                    return
+                    return nil
                 else
                     match
                 end

--- a/lib/utilrb/pkgconfig.rb
+++ b/lib/utilrb/pkgconfig.rb
@@ -439,7 +439,11 @@ module Utilrb
 
 	ACTIONS = %w{cflags cflags-only-I cflags-only-other 
 		    libs libs-only-L libs-only-l libs-only-other}
-	ACTIONS.each { |action| define_pkgconfig_action(action) }
+    ACTIONS.each { |action| define_pkgconfig_action(action) }
+    
+        def conflicts
+            @conflicts
+        end
 
         def raw_cflags
             @cflags

--- a/test/data/test_pkgconfig_recursive_conflict_loop_a.pc
+++ b/test/data/test_pkgconfig_recursive_conflict_loop_a.pc
@@ -1,0 +1,9 @@
+prefix=a_prefix
+
+Name: test_pkgconfig_recursive_conflict_loop_a
+Description:
+Version: 4.2
+
+Conflicts: test_pkgconfig_recursive_conflict_loop_b test_pkgconfig_recursive_conflict_loop_c 
+Cflags: -Owith_requires -Iwith_requires
+Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_conflict_loop_b.pc
+++ b/test/data/test_pkgconfig_recursive_conflict_loop_b.pc
@@ -1,0 +1,9 @@
+prefix=a_prefix
+
+Name: test_pkgconfig_recursive_confict_loop_b
+Description:
+Version: 4.2
+
+Conflicts: test_pkgconfig_recursive_conflict_loop_a test_pkgconfig_recursive_conflict_loop_b test_pkgconfig_recursive_conflict_loop_d
+Cflags: -Owith_requires -Iwith_requires
+Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_conflict_loop_c.pc
+++ b/test/data/test_pkgconfig_recursive_conflict_loop_c.pc
@@ -1,9 +1,9 @@
 prefix=a_prefix
 
-Name: test_pkgconfig_recursive_require_loop_b
+Name: test_pkgconfig_recursive_conflict_loop_c
 Description:
 Version: 4.2
 
-Requires: test_pkgconfig_recursive_require_loop_b test_pkgconfig_recursive_require_loop_d
+Requires: 
 Cflags: -Owith_requires -Iwith_requires
 Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_conflict_loop_d.pc
+++ b/test/data/test_pkgconfig_recursive_conflict_loop_d.pc
@@ -1,9 +1,9 @@
 prefix=a_prefix
 
-Name: test_pkgconfig_recursive_require_loop_b
+Name: test_pkgconfig_recursive_conflict_loop_d
 Description:
 Version: 4.2
 
-Requires: test_pkgconfig_recursive_require_loop_b test_pkgconfig_recursive_require_loop_d
+Requires: 
 Cflags: -Owith_requires -Iwith_requires
 Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_noloop_require_a.pc
+++ b/test/data/test_pkgconfig_recursive_noloop_require_a.pc
@@ -1,0 +1,9 @@
+prefix=a_prefix
+
+Name: test_pkgconfig_recursive_noloop_require_a
+Description:
+Version: 4.2
+
+Requires: test_pkgconfig_recursive_noloop_require_b test_pkgconfig_recursive_noloop_require_c 
+Cflags: -Owith_requires -Iwith_requires
+Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_noloop_require_b.pc
+++ b/test/data/test_pkgconfig_recursive_noloop_require_b.pc
@@ -1,9 +1,9 @@
 prefix=a_prefix
 
-Name: test_pkgconfig_recursive_require_loop_b
+Name: test_pkgconfig_recursive_noloop_require_b
 Description:
 Version: 4.2
 
-Requires: test_pkgconfig_recursive_require_loop_b test_pkgconfig_recursive_require_loop_d
+Requires: test_pkgconfig_recursive_noloop_require_c 
 Cflags: -Owith_requires -Iwith_requires
 Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_noloop_require_c.pc
+++ b/test/data/test_pkgconfig_recursive_noloop_require_c.pc
@@ -1,9 +1,9 @@
 prefix=a_prefix
 
-Name: test_pkgconfig_recursive_require_loop_b
+Name: test_pkgconfig_recursive_noloop_require_c
 Description:
 Version: 4.2
 
-Requires: test_pkgconfig_recursive_require_loop_b test_pkgconfig_recursive_require_loop_d
+Requires: 
 Cflags: -Owith_requires -Iwith_requires
 Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_require_loop_a.pc
+++ b/test/data/test_pkgconfig_recursive_require_loop_a.pc
@@ -1,0 +1,9 @@
+prefix=a_prefix
+
+Name: test_pkgconfig_recursive_require_loop_a
+Description:
+Version: 4.2
+
+Requires: test_pkgconfig_recursive_require_loop_b test_pkgconfig_recursive_require_loop_c 
+Cflags: -Owith_requires -Iwith_requires
+Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_require_loop_b.pc
+++ b/test/data/test_pkgconfig_recursive_require_loop_b.pc
@@ -4,6 +4,6 @@ Name: test_pkgconfig_recursive_require_loop_b
 Description:
 Version: 4.2
 
-Requires: test_pkgconfig_recursive_require_loop_a test_pkgconfig_recursive_require_loop_d
+Requires: test_pkgconfig_recursive_require_loop_a test_pkgconfig_recursive_require_loop_b test_pkgconfig_recursive_require_loop_d
 Cflags: -Owith_requires -Iwith_requires
 Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_require_loop_b.pc
+++ b/test/data/test_pkgconfig_recursive_require_loop_b.pc
@@ -1,0 +1,9 @@
+prefix=a_prefix
+
+Name: test_pkgconfig_recursive_require_loop_b
+Description:
+Version: 4.2
+
+Requires: test_pkgconfig_recursive_require_loop_a test_pkgconfig_recursive_require_loop_d
+Cflags: -Owith_requires -Iwith_requires
+Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_require_loop_c.pc
+++ b/test/data/test_pkgconfig_recursive_require_loop_c.pc
@@ -1,0 +1,9 @@
+prefix=a_prefix
+
+Name: test_pkgconfig_recursive_require_loop_c
+Description:
+Version: 4.2
+
+Requires: 
+Cflags: -Owith_requires -Iwith_requires
+Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_recursive_require_loop_d.pc
+++ b/test/data/test_pkgconfig_recursive_require_loop_d.pc
@@ -1,0 +1,9 @@
+prefix=a_prefix
+
+Name: test_pkgconfig_recursive_require_loop_d
+Description:
+Version: 4.2
+
+Requires: 
+Cflags: -Owith_requires -Iwith_requires
+Libs: -lwith_requires -Lwith_requires -Wwith_requires

--- a/test/data/test_pkgconfig_version_not_number.pc
+++ b/test/data/test_pkgconfig_version_not_number.pc
@@ -3,7 +3,6 @@ prefix=a_prefix
 Name: test_pkgconfig_version_not_number
 Description: 
 Version: 4.2.1
-Requires:
-Requires.private: test_pkgconfig_recursive_require_loop_c >= test_pkgconfig_recursive_require_loop_d
+Requires: test_pkgconfig_recursive_require_loop_c >= test_pkgconfig_recursive_require_loop_d
 Cflags: -I${prefix}/include -O3
 Libs: -ltest -lother -L${prefix}/lib -Wopt

--- a/test/data/test_pkgconfig_version_not_number.pc
+++ b/test/data/test_pkgconfig_version_not_number.pc
@@ -1,0 +1,9 @@
+prefix=a_prefix
+
+Name: test_pkgconfig_version_not_number
+Description: 
+Version: 4.2.1
+Requires:
+Requires.private: test_pkgconfig_recursive_require_loop_c >= test_pkgconfig_recursive_require_loop_d
+Cflags: -I${prefix}/include -O3
+Libs: -ltest -lother -L${prefix}/lib -Wopt

--- a/test/data/test_pkgconfig_version_not_number_and_number.pc
+++ b/test/data/test_pkgconfig_version_not_number_and_number.pc
@@ -1,0 +1,8 @@
+prefix=a_prefix
+
+Name: test_pkgconfig_version_not_number_and_number
+Description: 
+Version: 4.2.1
+Requires: test_pkgconfig_recursive_require_loop_c >= test_pkgconfig_recursive_require_loop_d >= 0.2
+Cflags: -I${prefix}/include -O3
+Libs: -ltest -lother -L${prefix}/lib -Wopt

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -190,5 +190,10 @@ class TC_PkgConfig < Minitest::Test
         pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_version_not_number')[0]
         assert_equal ['test_pkgconfig_recursive_require_loop_c', 'test_pkgconfig_recursive_require_loop_d'],
             pkg.requires.map(&:name)
+
+        pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_version_not_number_and_number')[0]
+        assert_equal ['test_pkgconfig_recursive_require_loop_c', 'test_pkgconfig_recursive_require_loop_d'],
+            pkg.requires.map(&:name)
+            
     end
 end

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -66,7 +66,11 @@ class TC_PkgConfig < Minitest::Test
         # requirement has A >= B. We add it instead.
         "test_pkgconfig_version_not_number_and_number",
         "ignition-fuel_tools1",
-        "gazebo"
+        "gazebo",
+        "test_pkgconfig_recursive_conflict_loop_a",
+        "test_pkgconfig_recursive_conflict_loop_b",
+        "test_pkgconfig_recursive_require_loop_a",
+        "test_pkgconfig_recursive_require_loop_b"
     ]
 
     def test_comparison_with_cpkgconfig
@@ -176,41 +180,45 @@ class TC_PkgConfig < Minitest::Test
             pkg.requires.map(&:name)
     end
 
-    def test_recursive_requires
-        pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_require_loop_a')[0]
-        
-        assert_equal ['test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_c'],
-            pkg.requires.map(&:name)
+    def test_recursive_conflicts
+        pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_conflict_loop_a')[0]
+        assert_equal ['test_pkgconfig_recursive_conflict_loop_b', 'test_pkgconfig_recursive_conflict_loop_c'],
+            pkg.conflicts.map(&:name)
 
-
-        pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_require_loop_b')[0]
-        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_d'],
-            pkg.requires.map(&:name)
+        pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_conflict_loop_b')[0]
+        assert_equal ['test_pkgconfig_recursive_conflict_loop_a', 'test_pkgconfig_recursive_conflict_loop_b', 'test_pkgconfig_recursive_conflict_loop_d'],
+            pkg.conflicts.map(&:name)
     end
 
-    def test_recursive_requires_full_list
-        # A requires [B, C]
-        # B requires [A, B, D]
+    def test_recursive_requires
+        e = assert_raises(Utilrb::PkgConfig::DependencyLoop) do
+            Utilrb::PkgConfig.parse_dependencies 'test_pkgconfig_recursive_require_loop_a'
+        end
+    end
+
+    def test_recursive_conflict_full_list
+        # A conflicts [B, C]
+        # B conflicts [A, B, D]
 
         # When parsing A
-        pkgA = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_require_loop_a')[0]
-        assert_equal ['test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_c'],
-            pkgA.requires.map(&:name)
+        pkgA = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_conflict_loop_a')[0]
+        assert_equal ['test_pkgconfig_recursive_conflict_loop_b', 'test_pkgconfig_recursive_conflict_loop_c'],
+            pkgA.conflicts.map(&:name)
 
-        # B is the first requirement and it should require all dependencies [A, B, D]
-        pkgB = pkgA.requires[0]
-        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_d'],
-            pkgB.requires.map(&:name)
+        # B is the first conflict and it should conflict with [A, B, D]
+        pkgB = pkgA.conflicts[0]
+        assert_equal ['test_pkgconfig_recursive_conflict_loop_a', 'test_pkgconfig_recursive_conflict_loop_b', 'test_pkgconfig_recursive_conflict_loop_d'],
+            pkgB.conflicts.map(&:name)
 
         # When parsing B
-        pkgB = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_require_loop_b')[0]
-        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_d'],
-            pkgB.requires.map(&:name)
+        pkgB = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_conflict_loop_b')[0]
+        assert_equal ['test_pkgconfig_recursive_conflict_loop_a', 'test_pkgconfig_recursive_conflict_loop_b', 'test_pkgconfig_recursive_conflict_loop_d'],
+            pkgB.conflicts.map(&:name)
         
-        # A is the first requirement and it should require all dependencies [B, C]
-        pkgA = pkgB.requires[0] 
-        assert_equal ['test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_c'],
-            pkgA.requires.map(&:name)
+        # A is the first conflict and it should conflict with [B, C]
+        pkgA = pkgB.conflicts[0] 
+        assert_equal ['test_pkgconfig_recursive_conflict_loop_b', 'test_pkgconfig_recursive_conflict_loop_c'],
+            pkgA.conflicts.map(&:name)
     end
 
     def test_malformed_version_not_number
@@ -224,4 +232,18 @@ class TC_PkgConfig < Minitest::Test
         assert_equal ['test_pkgconfig_recursive_require_loop_c', 'test_pkgconfig_recursive_require_loop_d'],
             pkg.requires.map(&:name)  
     end
+
+    def test_recursive_noloop_require
+        # A requires [B, C]
+        # B requires [C] this is not a loop, but C is required two times
+        pkgA = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_noloop_require_a')[0]
+        assert_equal ['test_pkgconfig_recursive_noloop_require_b', 'test_pkgconfig_recursive_noloop_require_c'],
+            pkgA.requires.map(&:name)
+
+        # B is the first conflict and it should conflict with [A, B, D]
+        pkgB = pkgA.requires[0]
+        assert_equal ['test_pkgconfig_recursive_noloop_require_c'],
+            pkgB.requires.map(&:name)
+    end
+
 end

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -166,4 +166,14 @@ class TC_PkgConfig < Minitest::Test
         assert_equal ['test_pkgconfig'],
             pkg.requires.map(&:name)
     end
+
+    def test_recursive_requires
+        pkg = Utilrb::PkgConfig.get('test_pkgconfig_recursive_require_loop_a')
+        assert_equal ['test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_c'],
+            pkg.requires.map(&:name)
+
+        pkg = Utilrb::PkgConfig.get('test_pkgconfig_recursive_require_loop_b')
+        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_d'],
+            pkg.requires.map(&:name)        
+    end
 end

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -58,7 +58,7 @@ class TC_PkgConfig < Minitest::Test
 	assert_equal('', pkg.libs)
 	assert_equal('', pkg.libs_only_L)
 	assert_equal('', pkg.libs_only_l)
-        assert_equal([], pkg.library_dirs)
+    assert_equal([], pkg.library_dirs)
     end
 
     def test_comparison_with_cpkgconfig
@@ -168,12 +168,22 @@ class TC_PkgConfig < Minitest::Test
     end
 
     def test_recursive_requires
-        pkg = Utilrb::PkgConfig.get('test_pkgconfig_recursive_require_loop_a')
+        pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_require_loop_a')[0]
+        
         assert_equal ['test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_c'],
             pkg.requires.map(&:name)
 
-        pkg = Utilrb::PkgConfig.get('test_pkgconfig_recursive_require_loop_b')
-        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_d'],
-            pkg.requires.map(&:name)        
+        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_d'],
+            pkg.requires[0].requires.map(&:name)
+
+
+        pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_require_loop_b')[0]
+        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_d'],
+            pkg.requires.map(&:name)
+            
+        assert_equal ['test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_c'],
+            pkg.requires[0].requires.map(&:name)
+    
+    end
     end
 end

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -189,6 +189,6 @@ class TC_PkgConfig < Minitest::Test
     def test_version_not_number
         pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_version_not_number')[0]
         assert_equal ['test_pkgconfig_recursive_require_loop_c', 'test_pkgconfig_recursive_require_loop_d'],
-            pkg.requires_private.map(&:name)
+            pkg.requires.map(&:name)
     end
 end

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -213,14 +213,15 @@ class TC_PkgConfig < Minitest::Test
             pkgA.requires.map(&:name)
     end
 
-    def test_version_not_number
+    def test_malformed_version_not_number
         pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_version_not_number')[0]
         assert_equal ['test_pkgconfig_recursive_require_loop_c', 'test_pkgconfig_recursive_require_loop_d'],
             pkg.requires.map(&:name)
+    end
 
+    def test_malformed_version_not_number_and_number
         pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_version_not_number_and_number')[0]
         assert_equal ['test_pkgconfig_recursive_require_loop_c', 'test_pkgconfig_recursive_require_loop_d'],
-            pkg.requires.map(&:name)
-            
+            pkg.requires.map(&:name)  
     end
 end

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -61,8 +61,17 @@ class TC_PkgConfig < Minitest::Test
     assert_equal([], pkg.library_dirs)
     end
 
+    IGNORE_COMPARISON_WITH_CPKGCONFIG = [
+        # CPkgConfig silently ignores a B package when a
+        # requirement has A >= B. We add it instead.
+        "test_pkgconfig_version_not_number_and_number",
+        "ignition-fuel_tools1",
+        "gazebo"
+    ]
+
     def test_comparison_with_cpkgconfig
         PkgConfig.each_package do |name|
+            next if IGNORE_COMPARISON_WITH_CPKGCONFIG.include?(name)
             pkg = begin PkgConfig.new(name)
                   rescue PkgConfig::NotFound
                       `pkg-config --cflags #{name}`

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -185,5 +185,10 @@ class TC_PkgConfig < Minitest::Test
             pkg.requires[0].requires.map(&:name)
     
     end
+
+    def test_version_not_number
+        pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_version_not_number')[0]
+        assert_equal ['test_pkgconfig_recursive_require_loop_c', 'test_pkgconfig_recursive_require_loop_d'],
+            pkg.requires_private.map(&:name)
     end
 end

--- a/test/test_pkgconfig.rb
+++ b/test/test_pkgconfig.rb
@@ -182,17 +182,35 @@ class TC_PkgConfig < Minitest::Test
         assert_equal ['test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_c'],
             pkg.requires.map(&:name)
 
-        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_d'],
-            pkg.requires[0].requires.map(&:name)
-
 
         pkg = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_require_loop_b')[0]
         assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_d'],
             pkg.requires.map(&:name)
-            
+    end
+
+    def test_recursive_requires_full_list
+        # A requires [B, C]
+        # B requires [A, B, D]
+
+        # When parsing A
+        pkgA = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_require_loop_a')[0]
         assert_equal ['test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_c'],
-            pkg.requires[0].requires.map(&:name)
-    
+            pkgA.requires.map(&:name)
+
+        # B is the first requirement and it should require all dependencies [A, B, D]
+        pkgB = pkgA.requires[0]
+        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_d'],
+            pkgB.requires.map(&:name)
+
+        # When parsing B
+        pkgB = Utilrb::PkgConfig.parse_dependencies('test_pkgconfig_recursive_require_loop_b')[0]
+        assert_equal ['test_pkgconfig_recursive_require_loop_a', 'test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_d'],
+            pkgB.requires.map(&:name)
+        
+        # A is the first requirement and it should require all dependencies [B, C]
+        pkgA = pkgB.requires[0] 
+        assert_equal ['test_pkgconfig_recursive_require_loop_b', 'test_pkgconfig_recursive_require_loop_c'],
+            pkgA.requires.map(&:name)
     end
 
     def test_version_not_number


### PR DESCRIPTION
1) fix infinite loop when packages require each other (or conflict with each other):
A requires B
B requires C

2) workaround when version specification is not a number (just ignores it for now)